### PR TITLE
[SELC-2434] add DELETED status for userGroup - refactor RequestParam for getAllGroups

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -12,7 +12,7 @@
         "default" : "http://localhost"
       },
       "port" : {
-        "default" : "8080"
+        "default" : "80"
       },
       "basePath" : {
         "default" : ""
@@ -93,15 +93,21 @@
             "type" : "string",
             "format" : "uuid"
           }
-        }, {
-          "name" : "status",
-          "in" : "query",
-          "description" : "If filter on status is present, it must be used with at least one of the other filters",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ACTIVE", "SUSPENDED" ]
+        },  {
+          "name": "status",
+          "in": "query",
+          "description": "If filter on status is present, it must be used with at least one of the other filters",
+          "required": false,
+          "style": "form",
+          "schema": {
+            "type": "array",
+            "items": {
+              "enum": [
+                "ACTIVE",
+                "DELETED",
+                "SUSPENDED"
+              ]
+            }
           }
         } ],
         "responses" : {
@@ -596,8 +602,8 @@
           }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK"
+          "204" : {
+            "description" : "No Content"
           },
           "400" : {
             "description" : "Bad Request",
@@ -791,7 +797,7 @@
           "status" : {
             "type" : "string",
             "description" : "Users group's status",
-            "enum" : [ "ACTIVE", "SUSPENDED" ]
+            "enum" : [ "ACTIVE", "DELETED", "SUSPENDED" ]
           }
         }
       },
@@ -959,7 +965,7 @@
           "status" : {
             "type" : "string",
             "description" : "Users group's status",
-            "enum" : [ "ACTIVE", "SUSPENDED" ]
+            "enum" : [ "ACTIVE", "DELETED", "SUSPENDED" ]
           }
         }
       }

--- a/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/model/UserGroupFilter.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/model/UserGroupFilter.java
@@ -1,60 +1,30 @@
 package it.pagopa.selfcare.user_group.connector.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.springframework.util.CollectionUtils;
 
-import java.util.Optional;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @Data
+@AllArgsConstructor
 public class UserGroupFilter {
-    private Optional<String> institutionId;
-    private Optional<String> productId;
-    private Optional<String> userId;
-    private Optional<UserGroupStatus> status;
+    private String institutionId;
+    private String productId;
+    private String userId;
+    private List<UserGroupStatus> status;
 
-    public static UserGroupFilterBuilder builder() {
-        return new UserGroupFilterBuilder();
+    public UserGroupFilter(String institutionId, String productId, UUID userId, List<UserGroupStatus> status) {
+        this.institutionId = institutionId;
+        this.productId = productId;
+        this.userId = userId != null ? userId.toString() : null;
+        this.status = CollectionUtils.isEmpty(status) ? Collections.emptyList() : status;
     }
 
-    public static class UserGroupFilterBuilder {
-        private Optional<String> institutionId;
-        private Optional<String> productId;
-        private Optional<String> userId;
-        private Optional<UserGroupStatus> status;
-
-        private UserGroupFilterBuilder() {
-            this.productId = Optional.empty();
-            this.institutionId = Optional.empty();
-            this.userId = Optional.empty();
-            this.status = Optional.empty();
-        }
-
-        public UserGroupFilterBuilder institutionId(Optional<String> institutionId) {
-            this.institutionId = institutionId == null ? Optional.empty() : institutionId;
-            return this;
-        }
-
-        public UserGroupFilterBuilder productId(Optional<String> productId) {
-            this.productId = productId == null ? Optional.empty() : productId;
-            return this;
-        }
-
-        public UserGroupFilterBuilder userId(Optional<String> userId) {
-            this.userId = userId == null ? Optional.empty() : userId;
-            return this;
-        }
-
-        public UserGroupFilterBuilder status(Optional<UserGroupStatus> status) {
-            this.status = status == null ? Optional.empty() : status;
-            return this;
-        }
-
-        public UserGroupFilter build() {
-            UserGroupFilter filter = new UserGroupFilter();
-            filter.status = status;
-            filter.institutionId = institutionId;
-            filter.productId = productId;
-            filter.userId = userId;
-            return filter;
-        }
+    public UserGroupFilter(){
+        this.status = Collections.emptyList();
     }
+
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/model/UserGroupStatus.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/user_group/connector/model/UserGroupStatus.java
@@ -2,5 +2,6 @@ package it.pagopa.selfcare.user_group.connector.model;
 
 public enum UserGroupStatus {
     ACTIVE,
-    SUSPENDED
+    SUSPENDED,
+    DELETED
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/user_group/connector/dao/model/CriteriaBuilder.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/user_group/connector/dao/model/CriteriaBuilder.java
@@ -1,0 +1,50 @@
+package it.pagopa.selfcare.user_group.connector.dao.model;
+
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+public class CriteriaBuilder {
+
+    private Criteria criteria;
+    private boolean first;
+
+    private CriteriaBuilder() {
+        criteria = new Criteria();
+        first = true;
+    }
+
+    public static CriteriaBuilder builder() {
+        return new CriteriaBuilder();
+    }
+
+    public Criteria build() {
+        return criteria;
+    }
+
+    public CriteriaBuilder inIfNotEmpty(@NonNull String key, @Nullable List<?> value) {
+        if (value != null && !value.isEmpty()) {
+            if (first) {
+                criteria = Criteria.where(key).in(value);
+                first = false;
+            } else {
+                criteria = criteria.and(key).in(value);
+            }
+        }
+        return this;
+    }
+
+    public CriteriaBuilder isIfNotNull(@NonNull String key, @Nullable Object value) {
+        if (value != null) {
+            if (first) {
+                criteria = Criteria.where(key).is(value);
+                first = false;
+            } else {
+                criteria = criteria.and(key).is(value);
+            }
+        }
+        return this;
+    }
+}

--- a/web/src/main/java/it/pagopa/selfcare/user_group/web/controller/UserGroupController.java
+++ b/web/src/main/java/it/pagopa/selfcare/user_group/web/controller/UserGroupController.java
@@ -25,7 +25,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -166,20 +166,20 @@ public class UserGroupController {
     @ApiOperation(value = "", notes = "${swagger.user-group.groups.api.getUserGroups}")
     public Page<UserGroupResource> getUserGroups(@ApiParam("${swagger.user-group.model.institutionId}")
                                                  @RequestParam(value = "institutionId", required = false)
-                                                         Optional<String> institutionId,
+                                                         String institutionId,
                                                  @ApiParam("${swagger.user-group.model.productId}")
                                                  @RequestParam(value = "productId", required = false)
-                                                         Optional<String> productId,
+                                                         String productId,
                                                  @ApiParam("${swagger.user-group.model.memberId}")
                                                  @RequestParam(value = "userId", required = false)
-                                                         Optional<UUID> memberId,
+                                                         UUID memberId,
                                                  @ApiParam("${swagger.user-group.model.statusFilter}")
                                                  @RequestParam(value = "status", required = false)
-                                                         Optional<UserGroupStatus> status,
+                                                     List<UserGroupStatus> status,
                                                  Pageable pageable) {
         log.trace("getUserGroups start");
         log.debug("getUserGroups institutionId = {}, productId = {}, pageable = {}, status = {}", institutionId, productId, pageable, status);
-        UserGroupFilter filter = UserGroupFilter.builder().userId(memberId.map(UUID::toString)).institutionId(institutionId).productId(productId).status(status).build();
+        UserGroupFilter filter = new UserGroupFilter(institutionId, productId, memberId, status);
         Page<UserGroupResource> result = PageMapper.map(groupService.getUserGroups(filter, pageable)
                 .map(GroupMapper::toResource));
         log.debug("getUserGroups result = {}", result);

--- a/web/src/test/java/it/pagopa/selfcare/user_group/web/controller/UserGroupControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/user_group/web/controller/UserGroupControllerTest.java
@@ -293,7 +293,7 @@ class UserGroupControllerTest {
                 .thenAnswer(invocation -> {
                     final Pageable pageable = invocation.getArgument(1, Pageable.class);
                     return getPage(List.of(groupOperations), pageable, () -> pageable.isPaged()
-                            ? pageable.getPageSize() * pageable.getPageNumber() + 1
+                            ? (long) pageable.getPageSize() * pageable.getPageNumber() + 1
                             : 1);
                 });
         //when
@@ -329,10 +329,9 @@ class UserGroupControllerTest {
         verify(groupServiceMock, times(1))
                 .getUserGroups(filterCaptor.capture(), pageableCaptor.capture());
         UserGroupFilter capturedFilter = filterCaptor.getValue();
-        assertEquals(capturedFilter.getStatus().get(), allowedStatus);
-        assertEquals(capturedFilter.getProductId().get(), productId);
-        assertEquals(capturedFilter.getInstitutionId().get(), institutionId);
-        assertEquals(capturedFilter.getUserId().get(), userId);
+        assertEquals(capturedFilter.getProductId(), productId);
+        assertEquals(capturedFilter.getInstitutionId(), institutionId);
+        assertEquals(capturedFilter.getUserId(), userId);
         Pageable capturedPageable = pageableCaptor.getValue();
         assertTrue(capturedPageable.getSort().isUnsorted());
         assertEquals(page, capturedPageable.getPageNumber());


### PR DESCRIPTION
**List of Changes**
1. refactor API deleteGroup - add DELETED status for userGroup
2. refactor API getUserGroups - changed RequestParameter status from UserGroupStatus to List<UserGroupStatus>

**Motivation and Context**
    Logical rather than physical deletion of UserGroups

**How Has This Been Tested?**
1. Try to delete userGroup by its ID
2. Check its status from getById
3. Try to call getUserGroups with some state's filter

