### PR TITLE
Fix validator on UserGroupStatus field

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/user_group/web/model/UserGroupResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/user_group/web/model/UserGroupResource.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.user_group.connector.model.UserGroupStatus;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -33,7 +34,7 @@ public class UserGroupResource {
     private String description;
 
     @ApiModelProperty(value = "${swagger.user-group.model.status}", required = true)
-    @NotBlank
+    @NotNull
     private UserGroupStatus status;
 
     @ApiModelProperty(value = "${swagger.user-group.model.members}")


### PR DESCRIPTION
#### List of Changes

Fix validator on UserGroupStatus field

#### Motivation and Context

This fix is necessary to avoid error on validation UserGroupResource. In particular, for enum UserGroupStatus, validator has been changed from **NotBlank** to **NotNull**

#### How Has This Been Tested?

I have run ms locally and tested the API **/user-grooup** in GET and in POST