### PR TITLE
[SELC-4684] Fix: Remove throws exception when update user group for delete members return 0 on modificationCount

### DIFF
--- a/connector/dao/src/main/java/it/pagopa/selfcare/user_group/connector/dao/UserGroupConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/user_group/connector/dao/UserGroupConnectorImpl.java
@@ -127,7 +127,7 @@ public class UserGroupConnectorImpl implements UserGroupConnector {
                         .currentTimestamp(UserGroupEntity.Fields.modifiedAt),
                 UserGroupEntity.class);
         if (updateResult.getModifiedCount() == 0) {
-            throw new ResourceUpdateException(COULD_NOT_UPDATE_MESSAGE);
+            log.warn("No user to delete from UserGroup");
         }
         log.trace("deleteMembers end");
     }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/user_group/connector/dao/UserGroupConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/user_group/connector/dao/UserGroupConnectorImplTest.java
@@ -788,8 +788,8 @@ class UserGroupConnectorImplTest {
         //when
         Executable executable = () -> groupConnector.deleteMembers(memberId, institutionId, productId);
         //then
-        ResourceUpdateException resourceUpdateException = assertThrows(ResourceUpdateException.class, executable);
-        assertEquals("Couldn't update resource", resourceUpdateException.getMessage());
+        Assertions.assertDoesNotThrow(executable);
+
         ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
         ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
         verify(mongoTemplateMock, times(1))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Removed throws exception when update user group for delete members return 0 on modificationCount

#### Motivation and Context

When we delete a user, if they do not belong to any group, the group update returns a modificationCount = 0. Currently in this case, ms-user-group was throwing an exception. Instead, it is necessary for the procedure to complete without errors as the fact that a user does not belong to any group is a possible scenario.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.